### PR TITLE
Fix/CVE 2023 39810

### DIFF
--- a/config.source
+++ b/config.source
@@ -2,4 +2,4 @@
 # export TARGETARCH=$(arch)
 export TARGETARCH=$(dpkg --print-architecture)
 export DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-export  VERSION='0.2.0'
+export  VERSION='0.3.0a'

--- a/config.source
+++ b/config.source
@@ -2,4 +2,4 @@
 # export TARGETARCH=$(arch)
 export TARGETARCH=$(dpkg --print-architecture)
 export DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-export  VERSION='0.3.0a'
+export  VERSION='0.3.0'

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,7 @@
 ---
 docker:
-  latest: false
+  latest: true
+  alias: dnsmasq
   version: '{{ VERSION }}'
   registry: docker.io
   filepath: docker

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,6 @@
 ---
 docker:
-  latest: true
-  alias: dnsmasq
+  latest: false
   version: '{{ VERSION }}'
   registry: docker.io
   filepath: docker

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -15,8 +15,8 @@ RUN  apt update && apt -y upgrade && \
      libhogweed6t64 libgmp10 libnftables1 libsystemd0 libunistring5 libnfnetlink0 \
      libmnl0 libxtables12 libjansson4 libcap2 libnftnl11 dns-root-data && \
      apt download openssl ca-certificates libssl3t64 libcrypt1 libzstd1 zlib1g perl-base perl-modules-5.40 perl && \
-     apt download libpcre2-8-0 libselinux1 base-files netbase dash coreutils mawk && \
-     apt download dnscrypt-proxy libc6 && \
+     apt download libpcre2-8-0 libselinux1 libacl1 libattr1 libc6 base-files netbase dash coreutils debianutils sed mawk && \
+     apt download dnscrypt-proxy && \
      ls /tmp/*.deb|xargs -I{} dpkg -x {} /scratch && \
      ls /tmp/*.deb|xargs -I{} dpkg-deb -f {} >>/scratch/var/lib/dpkg/status && \
      sed -i 's/Package/\nPackage/g' /scratch/var/lib/dpkg/status && \
@@ -25,9 +25,8 @@ RUN  apt update && apt -y upgrade && \
      find /tmp -name \*.deb |sed 's/%/:/'| sed 's|/tmp/||' | awk -F_ '{print $1,$2}' >>/scratch/var/lib/dpkg/list.txt && \
      printf "%s\n" '/bin/sh' '/bin/dash' '/usr/bin/sh' '/usr/bin/dash' >/scratch/etc/shells && \
      rm -fr /scratch/usr/share/{doc,man,locale,common-licenses} && \
-     tar cvf - /var/cache/dnscrypt-proxy /var/log/dnscrypt-proxy /etc/ca-certificates.conf \
-        /etc/passwd /etc/group /etc/shadow /etc/gshadow \
-           | (cd /scratch; tar xvfp -)
+     tar cvf - /etc/ca-certificates.conf /etc/passwd /etc/group /etc/shadow /etc/gshadow \
+        | (cd /scratch; tar xvfp -)
 
 #----------------------------------------------------------------------------------------------------
 FROM scratch

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -15,7 +15,7 @@ RUN  apt update && apt -y upgrade && \
      libhogweed6t64 libgmp10 libnftables1 libsystemd0 libunistring5 libnfnetlink0 \
      libmnl0 libxtables12 libjansson4 libcap2 libnftnl11 dns-root-data && \
      apt download openssl ca-certificates libssl3t64 libcrypt1 libzstd1 zlib1g perl-base perl-modules-5.40 perl && \
-     apt download base-files netbase busybox mawk && \
+     apt download libpcre2-8-0 libselinux1 base-files netbase dash coreutils mawk && \
      apt download dnscrypt-proxy libc6 && \
      ls /tmp/*.deb|xargs -I{} dpkg -x {} /scratch && \
      ls /tmp/*.deb|xargs -I{} dpkg-deb -f {} >>/scratch/var/lib/dpkg/status && \
@@ -23,9 +23,8 @@ RUN  apt update && apt -y upgrade && \
      sed -i 's/Description/Status: install ok installed\nDescription/g' /scratch/var/lib/dpkg/status && \
      sed -i 1d /scratch/var/lib/dpkg/status && \
      find /tmp -name \*.deb |sed 's/%/:/'| sed 's|/tmp/||' | awk -F_ '{print $1,$2}' >>/scratch/var/lib/dpkg/list.txt && \
-     printf /bin/sh > /scratch/etc/shells && \
+     printf "%s\n" '/bin/sh' '/bin/dash' '/usr/bin/sh' '/usr/bin/dash' >/scratch/etc/shells && \
      rm -fr /scratch/usr/share/{doc,man,locale,common-licenses} && \
-     cd /scratch/usr/bin && ln -s busybox sh && \
      tar cvf - /var/cache/dnscrypt-proxy /var/log/dnscrypt-proxy /etc/ca-certificates.conf \
         /etc/passwd /etc/group /etc/shadow /etc/gshadow \
            | (cd /scratch; tar xvfp -)
@@ -57,8 +56,7 @@ LABEL org.opencontainers.image.title="Lightweight DNS proxy with dnsmasq and DNS
       org.opencontainers.image.documentation="https://github.com/edelux/dns-proxy#readme" \
       org.opencontainers.image.vendor="edelux"
 
-RUN  /usr/bin/busybox --install -s && \
-     ln -sf /usr/bin/mawk /usr/bin/awk && \
+RUN  ln -sf /usr/bin/mawk /usr/bin/awk && \
      ln -sf /usr/bin/mawk /usr/bin/nawk && \
      chmod 644 /etc/dnsmasq.conf /etc/dnscrypt-proxy/dnscrypt-proxy.toml && \
      update-ca-trust extract >/dev/null 2>&1 || update-ca-certificates >/dev/null 2>&1

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -14,8 +14,9 @@ RUN  apt update && apt -y upgrade && \
      apt download dnsmasq-base libidn2-0 libnetfilter-conntrack3 libnettle8t64 libdbus-1-3 \
      libhogweed6t64 libgmp10 libnftables1 libsystemd0 libunistring5 libnfnetlink0 \
      libmnl0 libxtables12 libjansson4 libcap2 libnftnl11 dns-root-data && \
-     apt download openssl ca-certificates libssl3t64 libcrypt1 libzstd1 zlib1g perl-base perl-modules-5.40 perl && \
-     apt download libpcre2-8-0 libselinux1 libacl1 libattr1 libc6 base-files netbase dash coreutils debianutils sed mawk && \
+     apt download openssl ca-certificates libssl3t64 libcrypt1 liblzma5 libmd0 libzstd1 libbz2-1.0 zlib1g && \
+     apt download libpcre2-8-0 libselinux1 libacl1 libattr1 libc6 base-files netbase dash coreutils \
+     debianutils dpkg perl-base perl-modules-5.40 perl tar sed mawk && \
      apt download dnscrypt-proxy && \
      ls /tmp/*.deb|xargs -I{} dpkg -x {} /scratch && \
      ls /tmp/*.deb|xargs -I{} dpkg-deb -f {} >>/scratch/var/lib/dpkg/status && \

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -23,7 +23,7 @@ RUN  apt update && apt -y upgrade && \
      sed -i 's/Package/\nPackage/g' /scratch/var/lib/dpkg/status && \
      sed -i 's/Description/Status: install ok installed\nDescription/g' /scratch/var/lib/dpkg/status && \
      sed -i 1d /scratch/var/lib/dpkg/status && \
-     find /tmp -name \*.deb |sed 's/%/:/'| sed 's|/tmp/||' | awk -F_ '{print $1,$2}' >>/scratch/var/lib/dpkg/list.txt && \
+     find /tmp -name \*.deb |sed 's/%/:/'| sed 's|/tmp/||' | awk -F_ '{print $1,$2}' >/scratch/var/lib/dpkg/list.txt && \
      printf "%s\n" '/bin/sh' '/bin/dash' '/usr/bin/sh' '/usr/bin/dash' >/scratch/etc/shells && \
      rm -fr /scratch/usr/share/{doc,man,locale,common-licenses} && \
      tar cvf - /etc/ca-certificates.conf /etc/passwd /etc/group /etc/shadow /etc/gshadow \


### PR DESCRIPTION
🐛 workaround for CVE-2023-39810 by replacing busybox

This commit addresses the security vulnerability CVE-2023-39810 affecting
BusyBox version 1.37.0-6+b1, which is present in the current image.

As a workaround, BusyBox has been removed and replaced with `dash` and
`coreutils`, providing safer and more reliable base utilities while
maintaining compatibility with standard POSIX tools.

This change mitigates the exposure to the known vulnerability and
prepares the base for future hardened builds.